### PR TITLE
fix: voxtral partial transcription on long recordings

### DIFF
--- a/PetalKit/Sources/MLXClient/MLXClient.swift
+++ b/PetalKit/Sources/MLXClient/MLXClient.swift
@@ -267,7 +267,7 @@ private actor LiveMLXRuntime {
         case .mini3b, .mini3b8bit:
             log("prepare.voxtral.begin model=\(model.rawValue)")
             var config = VoxtralPipeline.Configuration.default
-            config.maxTokens = 256
+            config.maxTokens = 1024
             config.temperature = 0.0
             config.topP = 0.95
             config.repetitionPenalty = 1.15

--- a/mlx-voxtral-swift/Sources/VoxtralCore/Configuration/MemoryOptimizationConfig.swift
+++ b/mlx-voxtral-swift/Sources/VoxtralCore/Configuration/MemoryOptimizationConfig.swift
@@ -49,7 +49,7 @@ public struct MemoryOptimizationConfig: Sendable {
         evalFrequency: 4,
         clearCacheOnEval: true,
         resetPeakMemory: true,
-        maxKVCacheSize: 4096
+        maxKVCacheSize: 8192
     )
 
     /// Ultra - extreme memory savings (for 8-16GB RAM)
@@ -57,7 +57,7 @@ public struct MemoryOptimizationConfig: Sendable {
         evalFrequency: 2,
         clearCacheOnEval: true,
         resetPeakMemory: true,
-        maxKVCacheSize: 2048
+        maxKVCacheSize: 4096
     )
 
     // MARK: - Auto-detection


### PR DESCRIPTION
## Summary
- Raised Voxtral `maxTokens` from 256 → 1024 so the model doesn't cut off mid-sentence on recordings >1.5 minutes
- Doubled KV cache limits for lower-RAM machines so audio context doesn't get evicted during generation

Closes #9