### PR TITLE
fix: shortcut recorder button only clickable on right edge

### DIFF
--- a/PetalKit/KeyboardShortcuts/Sources/KeyboardShortcuts/View/Recorder.swift
+++ b/PetalKit/KeyboardShortcuts/Sources/KeyboardShortcuts/View/Recorder.swift
@@ -49,6 +49,7 @@ extension KeyboardShortcuts {
 					onChange: onChange
 				)
 				.frame(width: 0, height: 0)
+			.allowsHitTesting(false)
 				HStack {
 					ZStack {
 						switch mode {


### PR DESCRIPTION
## Summary
- The hidden NSView backing the keyboard shortcut recorder was eating mouse events despite being 0x0 sized, making only the far-right edge of the RECORD pill clickable
- Added `allowsHitTesting(false)` since all click handling goes through the SwiftUI `onTapGesture` overlay anyway

Closes #8